### PR TITLE
Set the repository source to download the asset

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Pull alertgen tool
       shell: bash
-      run: gh release download -p 'alertgen'
+      run: gh release download -R scality/action-prom-render-test -p 'alertgen'
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 


### PR DESCRIPTION
When using the tool `gh` in a action, this tool can identify
the repository in the current working directory.
In the use case of an action, we are in the repository
that calls the action (`Cloudserver`, `Vault`, ...).
We want to download the asset from the repository
`action-prom-render-test` so must set this source explicitly.