### PR TITLE
Skip alertgen download if present

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Pull alertgen tool
       shell: bash
-      run: gh release download -R scality/action-prom-render-test -p 'alertgen'
+      run: gh release download -R scality/action-prom-render-test -p 'alertgen' --skip-existing
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 


### PR DESCRIPTION
This happens esp. when the action is called multiple times, to test multiple rules.